### PR TITLE
Rename PuppetJs/x-html to Juicy/juicy-html

### DIFF
--- a/data/repos.json
+++ b/data/repos.json
@@ -93,7 +93,7 @@
         "repository": "ghostoy/a-painter"
     },
     {
-        "repository": "PuppetJs/x-html"
+        "repository": "Juicy/juicy-html"
     },
     {
         "repository": "webf/x-toolkit"


### PR DESCRIPTION
We have renamed our component, and moved it to new organization.
