### PR TITLE
Add target _blank to external links

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,14 +76,14 @@
             <section class="what-is-wc section">
                 <h3>What are Web Components?</h3>
                 <p>Web Components are a collection of standards which are working their way through the W3C. They enable truly encapsulated and reusable components for the web. And if you think HTML5 changed the web, wait to see what Web Components will do.</p>
-                <p>For lots more information about it, including articles and presentations, check out <a href="http://webcomponents.org">webcomponents.org</a>.</p>
-                <p style="float: right;">— <a href="http://twitter.com/zenorocha/">Zeno Rocha</a>, project lead.</p>
+                <p>For lots more information about it, including articles and presentations, check out <a target="_blank" href="http://webcomponents.org">webcomponents.org</a>.</p>
+                <p style="float: right;">— <a target="_blank" href="http://twitter.com/zenorocha/">Zeno Rocha</a>, project lead.</p>
             </section>
 
             <!-- Submit your own -->
             <section class="submit-own section">
                 <h3>Submit your own</h3>
-                <p>Got a great idea for a custom element? Awesome! There are boilerplates for <a href="https://github.com/webcomponents/polymer-boilerplate">Polymer</a>, <a href="https://github.com/webcomponents/x-tag-boilerplate">X-Tag</a>, and <a href="https://github.com/webcomponents/element-boilerplate">VanillaJS</a> that you can fork and get up and running with a simple component.</p>
+                <p>Got a great idea for a custom element? Awesome! There are boilerplates for <a target="_blank" href="https://github.com/webcomponents/polymer-boilerplate">Polymer</a>, <a target="_blank" href="https://github.com/webcomponents/x-tag-boilerplate">X-Tag</a>, and <a target="_blank" href="https://github.com/webcomponents/element-boilerplate">VanillaJS</a> that you can fork and get up and running with a simple component.</p>
                 <p>When you're ready to go, submit it to the form below and it'll appear on this site for others to play and use!</p>
                 <form action="" id="form-github-add">
                     <input type="text" name="repo" id="repo" placeholder="https://github.com/me/my-element" required>
@@ -129,28 +129,28 @@
     </main>
 
     <footer class="credits">
-        <p>Made with <love-heart>♥</love-heart> by these guys and a bunch of awesome <a href="https://github.com/webcomponents/customelements.io/graphs/contributors">contributors</a>.</p>
+        <p>Made with <love-heart>♥</love-heart> by these guys and a bunch of awesome <a target="_blank" href="https://github.com/webcomponents/customelements.io/graphs/contributors">contributors</a>.</p>
         <ul>
             <li>
-                <p><a href="https://github.com/zenorocha">
+                <p><a target="_blank" href="https://github.com/zenorocha">
                     <img src="https://2.gravatar.com/avatar/e190023b66e2b8aa73a842b106920c93?size=50" alt="Zeno Rocha">
                     <span>Zeno Rocha</span>
                 </a></p>
             </li>
             <li>
-                <p><a href="https://github.com/bernarddeluna">
+                <p><a target="_blank" href="https://github.com/bernarddeluna">
                     <img src="https://2.gravatar.com/avatar/bc16c9be1e05e65395487b78b1cc72c0?size=50" alt="Bernard De Luna">
                     <span>Bernard De Luna</span>
                 </a></p>
             </li>
             <li>
-                <p><a href="https://github.com/djalmaaraujo">
+                <p><a target="_blank" href="https://github.com/djalmaaraujo">
                     <img src="https://2.gravatar.com/avatar/be74fd9a577ea5ef1ab2e7c71bcfa4b5?size=50" alt="Djalma Araújo">
                     <span>Djalma Araújo</span>
                 </a></p>
             </li>
             <li>
-                <p><a href="https://github.com/eduardolundgren">
+                <p><a target="_blank" href="https://github.com/eduardolundgren">
                     <img src="https://2.gravatar.com/avatar/42327de520e674a6d1686845b30778d0?size=50" alt="Eduardo Lundgren">
                     <span>Eduardo Lundgren</span>
                 </a></p>
@@ -161,7 +161,7 @@
     <script type="text/template" id="list-template">
         <dl class="dl-horizontal">
             <% _.each(modules, function (el) { %>
-                <dt><a href="<%- el.url %>"><%- el.name %></a></dt>
+                <dt><a target="_blank" href="<%- el.url %>"><%- el.name %></a></dt>
                 <dd><%- el.description %></dd>
             <% }); %>
         </dl>
@@ -184,11 +184,11 @@
             <tbody class="list">
                 <% _.each(modules, function (el) { %>
                     <tr>
-                        <td class="name"><a href="<%- el.url %>"><%- el.name %></a></td>
+                        <td class="name"><a target="_blank" href="<%- el.url %>"><%- el.name %></a></td>
                         <td class="desc"><%- el.description %></td>
                         <td class="stars"><%- el.stars %></td>
                         <td class="forks"><%- el.forks %></td>
-                        <td class="author"><a href="<%- el.owner_url %>"><%- el.owner %></a></td>
+                        <td class="author"><a target="_blank" href="<%- el.owner_url %>"><%- el.owner %></a></td>
                     </tr>
                 <% }); %>
             </tbody>


### PR DESCRIPTION
We need to add target=_blank to all external links. The firefox marketplace need this to approve the site as an app.
The Firefox OS don't have the "Back" button by default, so they ask to add one or add target=_blank, that way the user can navigate through the app without been trapped.
